### PR TITLE
Add Provider Dashboard with calendar view (frontend UI)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import BookingPage from "./BookingPage";
 import AvailabilityPage from "./AvailabilityPage";
 import LoginSignup from "./components/LoginSignup/LoginSignup";
+import ProviderDashboard from "./ProviderDashboard";   
 import "./components/LoginSignup/LoginSignup.css";
 
 export default function App() {
@@ -16,6 +17,9 @@ export default function App() {
 
         {/* Availability */}
         <Route path="/availability" element={<AvailabilityPage />} />
+
+        {/* Provider Dashboard (calendar view) */}
+        <Route path="/provider" element={<ProviderDashboard />} /> 
       </Routes>
     </Router>
   );

--- a/frontend/src/ProviderDashboard.css
+++ b/frontend/src/ProviderDashboard.css
@@ -1,0 +1,130 @@
+.pd {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  
+  /* Header */
+  .pd__header h1 {
+    margin: 0;
+    color: #f1f5f9; /* bright */
+  }
+  
+  .pd__sub {
+    color: #cbd5e1; /* softer gray-blue */
+    margin: 0;
+  }
+  
+  /* Layout */
+  .pd__content {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 1rem;
+  }
+  @media (max-width: 940px) {
+    .pd__content {
+      grid-template-columns: 1fr;
+    }
+  }
+  
+  .pd__left {
+    position: relative;
+  }
+  
+  .pd__loading {
+    position: absolute;
+    right: .5rem;
+    top: .5rem;
+    background: #1e293b;
+    border: 1px solid #334155;
+    padding: .25rem .5rem;
+    border-radius: .5rem;
+    color: #f1f5f9;
+  }
+  
+  /* Panels */
+  .pd__right {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  
+  .pd__panel {
+    background: #1e293b;       /* slate gray */
+    border: 1px solid #334155; /* lighter border */
+    border-radius: .75rem;
+    padding: .75rem;
+    display: flex;
+    flex-direction: column;
+    gap: .5rem;
+  }
+  
+  .pd__date {
+    font-weight: 600;
+    color: #f8fafc;
+  }
+  
+  .pd__empty {
+    color: #94a3b8;
+    padding: .25rem 0;
+  }
+  
+  /* Lists */
+  .pd__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: .4rem;
+  }
+  
+  .pd__row {
+    display: grid;
+    grid-template-columns: 90px 1fr 90px;
+    gap: .5rem;
+    align-items: center;
+    background: #0f172a;
+    border: 1px solid #1e293b;
+    border-radius: .5rem;
+    padding: .4rem .5rem;
+  }
+  
+  .pd__time,
+  .pd__date {
+    font-variant-numeric: tabular-nums;
+    color: #e2e8f0;
+  }
+  
+  .pd__title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: #f1f5f9;
+  }
+  
+  /* Status Pills */
+  .pd__status {
+    justify-self: end;
+    text-transform: capitalize;
+    padding: .15rem .5rem;
+    border-radius: .5rem;
+    font-size: .8rem;
+    font-weight: 600;
+  }
+  
+  .pd__status--booked {
+    background: #2563eb;
+    color: #ffffff;
+  }
+  
+  .pd__status--cancelled {
+    background: #dc2626;
+    color: #ffffff;
+  }
+  
+  .pd__status--completed {
+    background: #16a34a;
+    color: #ffffff;
+  }
+  

--- a/frontend/src/ProviderDashboard.jsx
+++ b/frontend/src/ProviderDashboard.jsx
@@ -1,0 +1,104 @@
+import { useEffect, useMemo, useState } from "react";
+import Calendar from "./components/Calendar";
+import { fetchAppointments } from "./api";
+import "./ProviderDashboard.css";
+
+function startOfMonth(d) { return new Date(d.getFullYear(), d.getMonth(), 1); }
+function endOfMonth(d) { return new Date(d.getFullYear(), d.getMonth() + 1, 0); }
+function addMonths(d, n) { return new Date(d.getFullYear(), d.getMonth() + n, 1); }
+function fmt(d) { return d.toISOString().slice(0,10); }
+
+export default function ProviderDashboard() {
+  const [cursor, setCursor] = useState(startOfMonth(new Date()));
+  const [events, setEvents]   = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [selectedDay, setSelectedDay] = useState(() => fmt(new Date()));
+
+  const ym = useMemo(() => ({ y: cursor.getFullYear(), m: cursor.getMonth() }), [cursor]);
+
+  useEffect(() => {
+    const from = startOfMonth(cursor);
+    const to   = endOfMonth(cursor);
+    setLoading(true);
+    fetchAppointments(from, to)
+      .then(setEvents)
+      .finally(() => setLoading(false));
+  }, [cursor]);
+
+  const eventsForSelected = useMemo(
+    () => events.filter(e => e.date === selectedDay)
+                .sort((a,b) => a.start.localeCompare(b.start)),
+    [events, selectedDay]
+  );
+
+  const upcoming = useMemo(() => {
+    const today = new Date();
+    const todayKey = fmt(today);
+    return events
+      .filter(e => e.date >= todayKey)
+      .sort((a,b) => (a.date + a.start).localeCompare(b.date + b.start))
+      .slice(0, 8);
+  }, [events]);
+
+  return (
+    <div className="pd">
+      <div className="pd__header">
+        <h1>Provider Dashboard</h1>
+        <p className="pd__sub">View and manage your appointments.</p>
+      </div>
+
+      <div className="pd__content">
+        <div className="pd__left">
+          <Calendar
+            year={ym.y}
+            month={ym.m}
+            events={events}
+            onPrev={() => setCursor(c => addMonths(c, -1))}
+            onNext={() => setCursor(c => addMonths(c, 1))}
+            onToday={() => setCursor(startOfMonth(new Date()))}
+            onSelectDate={setSelectedDay}
+          />
+          {loading && <div className="pd__loading">Loading…</div>}
+        </div>
+
+        <div className="pd__right">
+          <section className="pd__panel">
+            <h2>Selected Day</h2>
+            <div className="pd__date">{selectedDay}</div>
+            {eventsForSelected.length === 0 ? (
+              <div className="pd__empty">No appointments.</div>
+            ) : (
+              <ul className="pd__list">
+                {eventsForSelected.map(e => (
+                  <li key={e.id} className="pd__row">
+                    <div className="pd__time">{e.start}-{e.end}</div>
+                    <div className="pd__title">{e.title}</div>
+                    <div className={`pd__status pd__status--${e.status}`}>{e.status}</div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          <section className="pd__panel">
+            <h2>Upcoming (next 8)</h2>
+            {upcoming.length === 0 ? (
+              <div className="pd__empty">Nothing scheduled.</div>
+            ) : (
+              <ul className="pd__list">
+                {upcoming.map(e => (
+                  <li key={e.id} className="pd__row">
+                    <div className="pd__date">{e.date}</div>
+                    <div className="pd__time">{e.start}-{e.end}</div>
+                    <div className="pd__title">{e.title}</div>
+                    <div className={`pd__status pd__status--${e.status}`}>{e.status}</div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,44 @@
+// Minimal API client with a mock fallback.
+// Backend contract expected at: GET /api/appointments?from=YYYY-MM-DD&to=YYYY-MM-DD
+// Response shape (example):
+// [{ id, customerName, date: '2025-08-19', start_time: '09:00', end_time: '09:30', status, notes }]
+
+function toISODate(d) {
+    return d.toISOString().slice(0, 10);
+  }
+  
+  export async function fetchAppointments(rangeStart, rangeEnd) {
+    const from = typeof rangeStart === "string" ? rangeStart : toISODate(rangeStart);
+    const to = typeof rangeEnd === "string" ? rangeEnd : toISODate(rangeEnd);
+    try {
+      const res = await fetch(`/api/appointments?from=${from}&to=${to}`, { credentials: "include" });
+      if (!res.ok) throw new Error("Bad status");
+      const data = await res.json();
+      return data.map(a => ({
+        id: a.id,
+        title: a.customerName || "Appointment",
+        date: a.date,             // YYYY-MM-DD
+        start: a.start_time,      // HH:mm
+        end: a.end_time,          // HH:mm
+        status: a.status || "booked",
+        notes: a.notes || ""
+      }));
+    } catch {
+      // Mock data so the page works before backend is ready.
+      const today = new Date();
+      const pad = n => String(n).padStart(2, "0");
+      const d = (offset) => {
+        const t = new Date(today);
+        t.setDate(t.getDate() + offset);
+        return `${t.getFullYear()}-${pad(t.getMonth()+1)}-${pad(t.getDate())}`;
+      };
+      return [
+        { id: 1, title: "John Smith", date: d(0),  start: "09:00", end: "09:30", status: "booked" },
+        { id: 2, title: "Aisha Noor",  date: d(1),  start: "13:00", end: "13:30", status: "booked" },
+        { id: 3, title: "M. Chen",     date: d(2),  start: "10:00", end: "10:30", status: "booked" },
+        { id: 4, title: "Follow-up",   date: d(2),  start: "15:00", end: "15:30", status: "booked" },
+        { id: 5, title: "Walk-in",     date: d(7),  start: "11:00", end: "11:30", status: "booked" }
+      ];
+    }
+  }
+  

--- a/frontend/src/components/Calendar.css
+++ b/frontend/src/components/Calendar.css
@@ -1,0 +1,115 @@
+.cal {
+    display: flex;
+    flex-direction: column;
+    gap: .75rem;
+  }
+  
+  .cal__toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  
+  .cal__left,
+  .cal__right {
+    display: flex;
+    gap: .5rem;
+  }
+  
+  .cal__btn {
+    padding: .35rem .6rem;
+    border: 1px solid #334155;
+    background: #1e293b;
+    color: #f1f5f9;
+    border-radius: .5rem;
+    cursor: pointer;
+  }
+  .cal__btn:hover {
+    background: #334155;
+  }
+  
+  .cal__label {
+    font-weight: 700;
+    font-size: 1.1rem;
+    color: #f8fafc;
+  }
+  
+  .cal__grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    grid-auto-rows: 110px;
+    gap: 2px;
+    background: #0f172a;
+    border: 1px solid #1e293b;
+    border-radius: .75rem;
+    overflow: hidden;
+  }
+  
+  .cal__dow {
+    background: #0f172a;
+    color: #94a3b8;
+    font-size: .85rem;
+    padding: .5rem .6rem;
+    border-bottom: 1px solid #334155;
+  }
+  
+  .cal__cell {
+    background: #1e293b;
+    color: #f1f5f9;
+    text-align: left;
+    padding: .4rem;
+    border: none;
+    cursor: pointer;
+    position: relative;
+  }
+  .cal__cell:hover {
+    background: #334155;
+  }
+  .cal__cell--muted {
+    color: #64748b;
+    background: #0f172a;
+  }
+  .cal__cell--today {
+    outline: 2px solid #3b82f6;
+    z-index: 1;
+  }
+  
+  .cal__date {
+    font-size: .9rem;
+    font-weight: 600;
+    margin-bottom: .25rem;
+  }
+  
+  .cal__events {
+    display: flex;
+    flex-direction: column;
+    gap: .25rem;
+  }
+  
+  .cal__pill {
+    display: inline-flex;
+    align-items: center;
+    gap: .4rem;
+    padding: .15rem .4rem;
+    border-radius: .4rem;
+    background: #334155;
+    color: #f8fafc;
+    font-size: .78rem;
+    width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  
+  .cal__pill-dot {
+    width: .5rem;
+    height: .5rem;
+    border-radius: 999px;
+    background: #60a5fa;
+  }
+  
+  .cal__pill-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  

--- a/frontend/src/components/Calendar.jsx
+++ b/frontend/src/components/Calendar.jsx
@@ -1,0 +1,103 @@
+import { useMemo } from "react";
+import "./Calendar.css";
+
+/**
+ * props:
+ *  - year, month (0-based month)
+ *  - events: [{ id, title, date:'YYYY-MM-DD', start:'HH:mm', end:'HH:mm', status }]
+ *  - onPrev(), onNext(), onToday()
+ *  - onSelectDate(yyyy_mm_dd)
+ */
+export default function Calendar({
+  year, month, events = [],
+  onPrev, onNext, onToday, onSelectDate
+}) {
+  const { weeks, label, eventsByDay, todayKey } = useMemo(() => {
+    const monthStart = new Date(year, month, 1);
+    const monthEnd   = new Date(year, month + 1, 0);
+    const start = new Date(monthStart);
+    start.setDate(start.getDate() - ((start.getDay() + 7) % 7)); // start on Sunday
+
+    const end = new Date(monthEnd);
+    end.setDate(end.getDate() + (6 - ((end.getDay() + 7) % 7))); // end on Saturday
+
+    // Map events by YYYY-MM-DD
+    const map = new Map();
+    for (const ev of events) {
+      const key = ev.date;
+      if (!map.has(key)) map.set(key, []);
+      map.get(key).push(ev);
+    }
+
+    const weeks = [];
+    let cursor = new Date(start);
+    while (cursor <= end) {
+      const week = [];
+      for (let i = 0; i < 7; i++) {
+        const y = cursor.getFullYear();
+        const m = String(cursor.getMonth() + 1).padStart(2, "0");
+        const d = String(cursor.getDate()).padStart(2, "0");
+        const key = `${y}-${m}-${d}`;
+        week.push({
+          key,
+          inMonth: cursor.getMonth() === month,
+          dateNum: cursor.getDate(),
+          events: (map.get(key) || []).slice(0, 3) // show up to 3 badges
+        });
+        cursor.setDate(cursor.getDate() + 1);
+      }
+      weeks.push(week);
+    }
+
+    const label = monthStart.toLocaleString(undefined, { month: "long", year: "numeric" });
+    const t = new Date();
+    const tk = `${t.getFullYear()}-${String(t.getMonth()+1).padStart(2,"0")}-${String(t.getDate()).padStart(2,"0")}`;
+
+    return { weeks, label, eventsByDay: map, todayKey: tk };
+  }, [year, month, events]);
+
+  const weekdays = ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"];
+
+  return (
+    <div className="cal">
+      <div className="cal__toolbar">
+        <div className="cal__left">
+          <button onClick={onPrev} className="cal__btn">‹</button>
+          <button onClick={onToday} className="cal__btn">Today</button>
+          <button onClick={onNext} className="cal__btn">›</button>
+        </div>
+        <div className="cal__label">{label}</div>
+        <div className="cal__right" />
+      </div>
+
+      <div className="cal__grid">
+        {weekdays.map(w => <div key={w} className="cal__dow">{w}</div>)}
+
+        {weeks.map((week, wi) =>
+          week.map((cell, ci) => (
+            <button
+              key={cell.key}
+              className={
+                "cal__cell" +
+                (cell.inMonth ? "" : " cal__cell--muted") +
+                (cell.key === todayKey ? " cal__cell--today" : "")
+              }
+              onClick={() => onSelectDate?.(cell.key)}
+              title={cell.key}
+            >
+              <div className="cal__date">{cell.dateNum}</div>
+              <div className="cal__events">
+                {cell.events.map(e => (
+                  <div key={e.id} className="cal__pill" title={`${e.title} ${e.start}-${e.end}`}>
+                    <span className="cal__pill-dot" />
+                    <span className="cal__pill-text">{e.start} {e.title}</span>
+                  </div>
+                ))}
+              </div>
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description
This PR adds the **Provider Dashboard** UI with a calendar view.

### Implemented
- Monthly calendar component (`Calendar.jsx`) with navigation (Prev/Next/Today) and selectable days.
- `ProviderDashboard.jsx` page that:
  - Fetches appointments for the current month (uses mock data fallback).
  - Shows a **Selected Day** list of appointments.
  - Displays an **Upcoming (next 8)** appointments list.
- Added `api.js` helper for fetching appointments.
- Applied new CSS styles for better readability on dark theme.
- Updated `App.jsx` to include `/provider` route.

### Notes
- This is **view-only** right now: provider can see appointments but not yet manage (cancel/reschedule/complete).
- Hooks are in place for backend integration once API endpoints are ready.
- Styling uses a unified dark theme.

### Testing
- Navigated between months, selected days, and verified appointment lists update correctly.
- Verified mock data loads when backend is unavailable.
- Checked responsiveness (desktop + mobile view).
