### PR TITLE
Backend/calendar data api

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" default="true" project-jdk-name="23" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_24" default="true" project-jdk-name="23" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/backend/src/main/java/com/rihal/AppointmentScheduler/controller/CalendarController.java
+++ b/backend/src/main/java/com/rihal/AppointmentScheduler/controller/CalendarController.java
@@ -1,0 +1,69 @@
+package com.rihal.AppointmentScheduler.controller;
+
+import com.rihal.AppointmentScheduler.dto.CalendarResponse;
+import com.rihal.AppointmentScheduler.dto.DayBucketDTO;
+import com.rihal.AppointmentScheduler.dto.MonthBucketDTO;
+import com.rihal.AppointmentScheduler.dto.WeekBucketDTO;
+import com.rihal.AppointmentScheduler.service.CalendarService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.Locale;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/calendar")
+@CrossOrigin(origins = "http://localhost:5173")
+public class CalendarController {
+
+    private final CalendarService service;
+
+    public CalendarController(CalendarService service) {
+        this.service = service;
+    }
+
+    /**
+     * Group by day
+     * GET /api/calendar/provider/{providerId}/daily?start=2025-08-01&end=2025-08-31&includeCancelled=false
+     */
+    @GetMapping("/provider/{providerId}/daily")
+    public ResponseEntity<CalendarResponse<DayBucketDTO>> byDay(@PathVariable UUID providerId,
+                                                                @RequestParam String start,
+                                                                @RequestParam String end,
+                                                                @RequestParam(defaultValue = "false") boolean includeCancelled) {
+        LocalDate s = LocalDate.parse(start);
+        LocalDate e = LocalDate.parse(end);
+        return ResponseEntity.ok(service.daily(providerId, s, e, includeCancelled));
+    }
+
+    /**
+     * Group by week (ISO, Locale-aware)
+     * GET /api/calendar/provider/{providerId}/weekly?start=2025-07-01&end=2025-08-31&includeCancelled=false&locale=en-US
+     */
+    @GetMapping("/provider/{providerId}/weekly")
+    public ResponseEntity<CalendarResponse<WeekBucketDTO>> byWeek(@PathVariable UUID providerId,
+                                                                  @RequestParam String start,
+                                                                  @RequestParam String end,
+                                                                  @RequestParam(defaultValue = "false") boolean includeCancelled,
+                                                                  @RequestParam(defaultValue = "en-US") String locale) {
+        LocalDate s = LocalDate.parse(start);
+        LocalDate e = LocalDate.parse(end);
+        Locale loc = Locale.forLanguageTag(locale);
+        return ResponseEntity.ok(service.weekly(providerId, s, e, includeCancelled, loc));
+    }
+
+    /**
+     * Group by month
+     * GET /api/calendar/provider/{providerId}/monthly?start=2025-01-01&end=2025-12-31&includeCancelled=true
+     */
+    @GetMapping("/provider/{providerId}/monthly")
+    public ResponseEntity<CalendarResponse<MonthBucketDTO>> byMonth(@PathVariable UUID providerId,
+                                                                    @RequestParam String start,
+                                                                    @RequestParam String end,
+                                                                    @RequestParam(defaultValue = "false") boolean includeCancelled) {
+        LocalDate s = LocalDate.parse(start);
+        LocalDate e = LocalDate.parse(end);
+        return ResponseEntity.ok(service.monthly(providerId, s, e, includeCancelled));
+    }
+}

--- a/backend/src/main/java/com/rihal/AppointmentScheduler/dto/AppointmentDTO.java
+++ b/backend/src/main/java/com/rihal/AppointmentScheduler/dto/AppointmentDTO.java
@@ -1,0 +1,19 @@
+package com.rihal.AppointmentScheduler.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class AppointmentDTO {
+    public UUID id;
+    public UUID customerId;
+    public UUID providerId;
+    public LocalDate date;
+    public LocalTime startTime;
+    public LocalTime endTime;
+    public String status;
+}
+

--- a/backend/src/main/java/com/rihal/AppointmentScheduler/dto/CalendarResponse.java
+++ b/backend/src/main/java/com/rihal/AppointmentScheduler/dto/CalendarResponse.java
@@ -1,0 +1,12 @@
+package com.rihal.AppointmentScheduler.dto;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.UUID; /** Generic envelope for calendar responses */
+public class CalendarResponse<T> {
+    public UUID providerId;
+    public LocalDate rangeStart;
+    public LocalDate rangeEnd;
+    public long total;        // total appointments in range (after filters)
+    public Map<String, T> buckets; // key depends on grouping (date, weekId, month)
+}

--- a/backend/src/main/java/com/rihal/AppointmentScheduler/dto/DayBucketDTO.java
+++ b/backend/src/main/java/com/rihal/AppointmentScheduler/dto/DayBucketDTO.java
@@ -1,0 +1,10 @@
+package com.rihal.AppointmentScheduler.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class DayBucketDTO {
+    public LocalDate date;
+    public long total;
+    public List<AppointmentDTO> items;
+}

--- a/backend/src/main/java/com/rihal/AppointmentScheduler/dto/MonthBucketDTO.java
+++ b/backend/src/main/java/com/rihal/AppointmentScheduler/dto/MonthBucketDTO.java
@@ -1,0 +1,10 @@
+package com.rihal.AppointmentScheduler.dto;
+
+import java.time.YearMonth;
+import java.util.List;
+
+public class MonthBucketDTO {
+    public YearMonth month;   // e.g. 2025-08
+    public long total;
+    public List<AppointmentDTO> items;
+}

--- a/backend/src/main/java/com/rihal/AppointmentScheduler/dto/WeekBucketDTO.java
+++ b/backend/src/main/java/com/rihal/AppointmentScheduler/dto/WeekBucketDTO.java
@@ -1,0 +1,13 @@
+package com.rihal.AppointmentScheduler.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class WeekBucketDTO {
+    public int week;          // ISO week number (1-53)
+    public int weekYear;      // ISO week-based-year
+    public LocalDate start;   // Monday
+    public LocalDate end;     // Sunday
+    public long total;
+    public List<AppointmentDTO> items;
+}

--- a/backend/src/main/java/com/rihal/AppointmentScheduler/repository/AppointmentRepository.java
+++ b/backend/src/main/java/com/rihal/AppointmentScheduler/repository/AppointmentRepository.java
@@ -15,22 +15,24 @@ import com.rihal.AppointmentScheduler.model.Appointment;
 import jakarta.persistence.LockModeType;
 
 public interface AppointmentRepository extends JpaRepository<Appointment, UUID> {
-    List<Appointment> findByProviderIdAndDateAndStatus(UUID providerId, LocalDate date, String status);
-    
+
+    // Find by provider and date, filtered by status (uses enum type-safety)
+    List<Appointment> findByProviderIdAndDateAndStatus(UUID providerId, LocalDate date, Appointment.Status status);
+
     // Find appointments by customer ID
     List<Appointment> findByCustomerId(UUID customerId);
-    
+
     // Find appointments by provider ID
     List<Appointment> findByProviderId(UUID providerId);
-    
-    // Check if another booked appointment overlaps the new requested slot
+
+    // Check if another booked appointment overlaps the requested slot
     @Query("""
         SELECT CASE WHEN COUNT(a) > 0 THEN TRUE ELSE FALSE END
         FROM Appointment a
-        WHERE a.provider.id = :providerId
+        WHERE a.providerId = :providerId
           AND a.date = :date
-          AND a.status = 'BOOKED'
-          AND a.id <> :appointmentId
+          AND a.status = com.rihal.AppointmentScheduler.model.Appointment.Status.BOOKED
+          AND (:appointmentId IS NULL OR a.id <> :appointmentId)
           AND (:newStart < a.endTime AND a.startTime < :newEnd)
         """)
     boolean existsOverlap(@Param("providerId") UUID providerId,
@@ -39,8 +41,9 @@ public interface AppointmentRepository extends JpaRepository<Appointment, UUID> 
                           @Param("newEnd") LocalTime newEnd,
                           @Param("appointmentId") UUID appointmentId);
 
+    // Lock provider's appointments on a given date to avoid race conditions
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT a FROM Appointment a WHERE a.provider.id = :providerId AND a.date = :date")
-    List<Appointment> findForUpdate(@Param("providerId") UUID providerId, @Param("date") LocalDate date);
-
+    @Query("SELECT a FROM Appointment a WHERE a.providerId = :providerId AND a.date = :date")
+    List<Appointment> findForUpdate(@Param("providerId") UUID providerId,
+                                    @Param("date") LocalDate date);
 }

--- a/backend/src/main/java/com/rihal/AppointmentScheduler/repository/AppointmentRepository.java
+++ b/backend/src/main/java/com/rihal/AppointmentScheduler/repository/AppointmentRepository.java
@@ -25,6 +25,9 @@ public interface AppointmentRepository extends JpaRepository<Appointment, UUID> 
     // Find appointments by provider ID
     List<Appointment> findByProviderId(UUID providerId);
 
+    // Add missing method for CalendarService
+    List<Appointment> findByProviderIdAndDateBetween(UUID providerId, LocalDate start, LocalDate end);
+
     // Check if another booked appointment overlaps the requested slot
     @Query("""
         SELECT CASE WHEN COUNT(a) > 0 THEN TRUE ELSE FALSE END

--- a/backend/src/main/java/com/rihal/AppointmentScheduler/repository/AvailabilityRepository.java
+++ b/backend/src/main/java/com/rihal/AppointmentScheduler/repository/AvailabilityRepository.java
@@ -2,6 +2,7 @@ package com.rihal.AppointmentScheduler.repository;
 
 import java.time.DayOfWeek;
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -17,7 +18,7 @@ public interface AvailabilityRepository extends JpaRepository<Availability, Long
 
     List<Availability> findByProviderIdAndIsActive(Long providerId, Boolean isActive);
 
-    List<Availability> findByProviderIdAndDayOfWeek(Long providerId, DayOfWeek dayOfWeek);
+    List<Availability> findByProviderIdAndDayOfWeek(UUID providerId, DayOfWeek dayOfWeek);
 
     @Query("SELECT a FROM Availability a WHERE a.provider.id = :providerId AND a.isActive = true ORDER BY a.dayOfWeek, a.startTime")
     List<Availability> findActiveAvailabilitiesByProvider(@Param("providerId") Long providerId);

--- a/backend/src/main/java/com/rihal/AppointmentScheduler/service/CalendarService.java
+++ b/backend/src/main/java/com/rihal/AppointmentScheduler/service/CalendarService.java
@@ -1,0 +1,132 @@
+package com.rihal.AppointmentScheduler.service;
+
+import com.rihal.AppointmentScheduler.dto.*;
+import com.rihal.AppointmentScheduler.model.Appointment;
+import com.rihal.AppointmentScheduler.repository.AppointmentRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.*;
+import java.time.temporal.WeekFields;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+public class CalendarService {
+
+    private final AppointmentRepository repo;
+
+    public CalendarService(AppointmentRepository repo) {
+        this.repo = repo;
+    }
+
+    public CalendarResponse<DayBucketDTO> daily(UUID providerId, LocalDate start, LocalDate end, boolean includeCancelled) {
+        List<Appointment> data = repo.findByProviderIdAndDateBetween(providerId, start, end);
+        List<Appointment> filtered = includeCancelled ? data
+                : data.stream().filter(a -> a.getStatus() == Appointment.Status.BOOKED).toList();
+
+        Map<LocalDate, List<Appointment>> grouped = filtered.stream()
+                .collect(Collectors.groupingBy(Appointment::getDate, TreeMap::new, Collectors.toList()));
+
+        Map<String, DayBucketDTO> buckets = new LinkedHashMap<>();
+        for (Map.Entry<LocalDate, List<Appointment>> e : grouped.entrySet()) {
+            DayBucketDTO b = new DayBucketDTO();
+            b.date = e.getKey();
+            b.items = e.getValue().stream().map(this::toDto).toList();
+            b.total = b.items.size();
+            buckets.put(e.getKey().toString(), b);
+        }
+
+        CalendarResponse<DayBucketDTO> resp = new CalendarResponse<>();
+        resp.providerId = providerId;
+        resp.rangeStart = start;
+        resp.rangeEnd = end;
+        resp.total = filtered.size();
+        resp.buckets = buckets;
+        return resp;
+    }
+
+    public CalendarResponse<WeekBucketDTO> weekly(UUID providerId, LocalDate start, LocalDate end, boolean includeCancelled, Locale locale) {
+        WeekFields wf = WeekFields.of(locale == null ? Locale.US : locale); // ISO weeks with Locale control
+        List<Appointment> data = repo.findByProviderIdAndDateBetween(providerId, start, end);
+        List<Appointment> filtered = includeCancelled ? data
+                : data.stream().filter(a -> a.getStatus() == Appointment.Status.BOOKED).toList();
+
+        record WeekKey(int weekYear, int week) {}
+        Function<Appointment, WeekKey> keyFn = a -> {
+            LocalDate d = a.getDate();
+            return new WeekKey(d.get(wf.weekBasedYear()), d.get(wf.weekOfWeekBasedYear()));
+        };
+
+        Map<WeekKey, List<Appointment>> grouped = filtered.stream()
+                .collect(Collectors.groupingBy(keyFn, TreeMap::new, Collectors.toList()));
+
+        Map<String, WeekBucketDTO> buckets = new LinkedHashMap<>();
+        for (Map.Entry<WeekKey, List<Appointment>> e : grouped.entrySet()) {
+            WeekKey k = e.getKey();
+            LocalDate weekStart = LocalDate
+                    .now()
+                    .withYear(k.weekYear)
+                    .with(wf.weekOfWeekBasedYear(), k.week)
+                    .with(wf.dayOfWeek(), 1); // Monday
+            LocalDate weekEnd = weekStart.plusDays(6);
+
+            WeekBucketDTO b = new WeekBucketDTO();
+            b.weekYear = k.weekYear;
+            b.week = k.week;
+            b.start = weekStart;
+            b.end = weekEnd;
+            b.items = e.getValue().stream().map(this::toDto).toList();
+            b.total = b.items.size();
+
+            String key = k.weekYear + "-W" + String.format("%02d", k.week);
+            buckets.put(key, b);
+        }
+
+        CalendarResponse<WeekBucketDTO> resp = new CalendarResponse<>();
+        resp.providerId = providerId;
+        resp.rangeStart = start;
+        resp.rangeEnd = end;
+        resp.total = filtered.size();
+        resp.buckets = buckets;
+        return resp;
+    }
+
+    public CalendarResponse<MonthBucketDTO> monthly(UUID providerId, LocalDate start, LocalDate end, boolean includeCancelled) {
+        List<Appointment> data = repo.findByProviderIdAndDateBetween(providerId, start, end);
+        List<Appointment> filtered = includeCancelled ? data
+                : data.stream().filter(a -> a.getStatus() == Appointment.Status.BOOKED).toList();
+
+        Map<YearMonth, List<Appointment>> grouped = filtered.stream()
+                .collect(Collectors.groupingBy(a -> YearMonth.from(a.getDate()), TreeMap::new, Collectors.toList()));
+
+        Map<String, MonthBucketDTO> buckets = new LinkedHashMap<>();
+        for (Map.Entry<YearMonth, List<Appointment>> e : grouped.entrySet()) {
+            MonthBucketDTO b = new MonthBucketDTO();
+            b.month = e.getKey();
+            b.items = e.getValue().stream().map(this::toDto).toList();
+            b.total = b.items.size();
+            buckets.put(e.getKey().toString(), b); // "2025-08"
+        }
+
+        CalendarResponse<MonthBucketDTO> resp = new CalendarResponse<>();
+        resp.providerId = providerId;
+        resp.rangeStart = start;
+        resp.rangeEnd = end;
+        resp.total = filtered.size();
+        resp.buckets = buckets;
+        return resp;
+    }
+
+    private AppointmentDTO toDto(Appointment a) {
+        AppointmentDTO d = new AppointmentDTO();
+        d.id = a.getId();
+        d.customerId = a.getCustomerId();
+        d.providerId = a.getProviderId();
+        d.date = a.getDate();
+        d.startTime = a.getStartTime();
+        d.endTime = a.getEndTime();
+        d.status = a.getStatus().name();
+        return d;
+    }
+}

--- a/backend/src/main/java/com/rihal/AppointmentScheduler/service/SlotService.java
+++ b/backend/src/main/java/com/rihal/AppointmentScheduler/service/SlotService.java
@@ -6,6 +6,7 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -29,18 +30,18 @@ public class SlotService {
         this.appointmentRepository = appointmentRepository;
     }
 
-    public List<LocalTime> getSlots(Long providerId, LocalDate date) {
+    public List<LocalTime> getSlots(UUID providerId, LocalDate date) {
         List<Availability> availabilities = availabilityRepository
                 .findByProviderIdAndDayOfWeek(providerId, date.getDayOfWeek());
-        
+
         if (availabilities.isEmpty()) return List.of();
-        
+
         // Get the first availability for the day (assuming one per day)
         Availability availability = availabilities.get(0);
 
         List<LocalTime> allSlots = enumerate(availability.getStartTime(), availability.getEndTime(), STEP);
         List<Appointment> booked = appointmentRepository
-                .findByProviderIdAndDateAndStatus(providerId, date, "BOOKED");
+                .findByProviderIdAndDateAndStatus(providerId, date, Appointment.Status.BOOKED);
 
         Set<LocalTime> taken = booked.stream()
                 .map(Appointment::getStartTime)


### PR DESCRIPTION
- Added CalendarController + CalendarService
- Group appointments by day, week, month
- Added SlotService
- Generate 30-min slots, exclude booked ones
- Updated repositories:
- findByProviderIdAndDateBetween
- existsOverlap
- findForUpdate (with lock)
- Unified providerId type to UUID